### PR TITLE
Going back to transport of flat vector without serialization

### DIFF
--- a/Steer/DigitizerWorkflow/src/CollisionTimePrinter.cxx
+++ b/Steer/DigitizerWorkflow/src/CollisionTimePrinter.cxx
@@ -48,21 +48,23 @@ DataProcessorSpec getCollisionTimePrinter() {
     auto header = o2::header::get<const o2::header::DataHeader>(dataref.header);
 	LOG(INFO) << "PAYLOAD SIZE " << header->payloadSize;
 
+    auto view = DataRefUtils::as<o2::MCInteractionRecord>(dataref);
+
     //auto view = DataRefUtils::as<int>(dataref);
     //LOG(INFO) << "## " << view[0] << "\n";
 
-	auto msg = DataRefUtils::as<TMessage>(dataref);
-	msg->Print();
-	return;
-    using T = std::vector<o2::MCInteractionRecord>;
-    auto cl = TClass::GetClass(typeid(T));
-    assert(cl);
-    auto records = static_cast<T*>(msg->ReadObjectAny(cl));
-    assert(records);
+//	auto msg = DataRefUtils::as<TMessage>(dataref);
+//	msg->Print();
+//	return;
+//    using T = std::vector<o2::MCInteractionRecord>;
+//    auto cl = TClass::GetClass(typeid(T));
+//    assert(cl);
+//    auto records = static_cast<T*>(msg->ReadObjectAny(cl));
+//    assert(records);
 
-    LOG(INFO) << "GOT " << records->size() << "times";
+    LOG(INFO) << "GOT " << view.size() << "times";
     int counter=0;
-    for (auto& collrecord : *records) {
+    for (auto& collrecord : view) {
       LOG(INFO) << "TIME " << counter++ << " : " << collrecord.timeNS;
     }
   };

--- a/Steer/DigitizerWorkflow/src/SimReaderSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/SimReaderSpec.cxx
@@ -45,16 +45,17 @@ DataProcessorSpec getSimReaderSpec() {
     auto& mgr = steer::HitProcessingManager::instance();
     auto eventrecords = mgr.getRunContext().getEventRecords();
 
+    LOG(INFO) << "SENDING " << eventrecords.size() << " records"; 
     // send data via data allocator
     // for times a flat buffer
-   // pc.allocator().snapshot(OutputSpec{ "SIM", "EVENTTIMES", 0, OutputSpec::Timeframe }, eventrecords);
+    pc.allocator().snapshot(OutputSpec{ "SIM", "EVENTTIMES", 0, OutputSpec::Timeframe }, eventrecords);
 
-    auto msg = new TMessage();
-    auto cl = TClass::GetClass(typeid(decltype(eventrecords)));
-    assert(cl);
-    msg->WriteObjectAny(&eventrecords, cl);
-
-    pc.allocator().adopt(OutputSpec{ "SIM", "EVENTTIMES", 0, OutputSpec::Timeframe }, msg);
+//    auto msg = new TMessage();
+//    auto cl = TClass::GetClass(typeid(decltype(eventrecords)));
+//    assert(cl);
+//    msg->WriteObjectAny(&eventrecords, cl);
+//
+//    pc.allocator().adopt(OutputSpec{ "SIM", "EVENTTIMES", 0, OutputSpec::Timeframe }, msg);
 
     //static int counter = 0;
     //pc.allocator().snapshot(OutputSpec{ "SIM", "EVENTTIMES", 0, OutputSpec::Timeframe }, counter++);


### PR DESCRIPTION
Got it working on Linux, the problem we have seen is most likely related to occupied ports on the system. Right now the port range is not configurable, but this is easy to fix.