### PR TITLE
Use PRIu64 rather than %llu.

### DIFF
--- a/Framework/Core/src/DataSpecUtils.cxx
+++ b/Framework/Core/src/DataSpecUtils.cxx
@@ -48,7 +48,7 @@ std::string DataSpecUtils::describe(InputSpec const& spec)
 void DataSpecUtils::describe(char* buffer, size_t size, InputSpec const& spec)
 {
   if (auto concrete = std::get_if<ConcreteDataMatcher>(&spec.matcher)) {
-    snprintf(buffer, size, "%s/%s/%llu",
+    snprintf(buffer, size, "%s/%s/%"PRIu64,
              concrete->origin.str,
              concrete->description.str,
              concrete->subSpec);


### PR DESCRIPTION
This is actually the way it should be, since the type is a `uint64_t`. This will avoid having warnings on other platforms.